### PR TITLE
Update pelican.php

### DIFF
--- a/pelican/pelican.php
+++ b/pelican/pelican.php
@@ -375,6 +375,7 @@ function pelican_CreateAccount(array $params) {
                 'backups' => (int) $backups,
             ],
             'deploy' => [
+		'tags' => [], // fix beta-8
                 'locations' => [(int) $location_id],
                 'dedicated_ip' => $dedicated_ip,
                 'port_range' => $port_range,


### PR DESCRIPTION
If is not present it will throw an error:

```
Array
(
    [errors] => Array
        (
            [0] => Array
                (
                    [code] => ValidationException
                    [status] => 422
                    [detail] => The deploy.tags field must be present.
                    [meta] => Array
                        (
                            [source_field] => deploy.tags
                            [rule] => present
                        )

                )

        )

    [status_code] => 422
)
```