### PR TITLE
Rename pelican-dev org references to pelican

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## WHMCS
 
-WHMCS Module for the [Pelican Panel](https://github.com/pelican-dev/panel/).
+WHMCS Module for the [Pelican Panel](https://github.com/pelican/panel/).
 
 ## Configuration support
 
@@ -34,7 +34,7 @@ This module requires the panel to be on version 1.0.0 and above.
 
 ## Credits
 
-[Dane](https://github.com/DaneEveritt) and [everyone else](https://github.com/pelican-dev/panel/graphs/contributors) involved in development of the Pelican Panel.
+[Dane](https://github.com/DaneEveritt) and [everyone else](https://github.com/pelican/panel/graphs/contributors) involved in development of the Pelican Panel.
 [death-droid](https://github.com/death-droid) for the original WHMCS module.
 
 # FAQ

--- a/pelican/pelican.php
+++ b/pelican/pelican.php
@@ -599,8 +599,8 @@ function pelican_LoginLink(array $params) {
 
         $hostname = pelican_GetHostname($params);
         echo '<a style="padding-right:3px" href="'.$hostname.'/admin/servers/view/' . $serverId . '" target="_blank">[Go to Service]</a>';
-        echo '<p style="float:right; padding-right:1.3%">[<a href="https://github.com/pelican-dev/whmcs/issues" target="_blank">Report A Bug</a>]</p>';
-        # echo '<p style="float: right">[<a href="https://github.com/pelican-dev/whmcs/issues" target="_blank">Report A Bug</a>]</p>';
+        echo '<p style="float:right; padding-right:1.3%">[<a href="https://github.com/pelican/whmcs/issues" target="_blank">Report A Bug</a>]</p>';
+        # echo '<p style="float: right">[<a href="https://github.com/pelican/whmcs/issues" target="_blank">Report A Bug</a>]</p>';
     } catch(Exception $err) {
         // Ignore
     }


### PR DESCRIPTION
**Do not merge this yet.** Holding it as a draft until the org move is finished, since the new paths don't resolve before then.

Nothing clever in this one, it's four links. Two in the README pointing at the panel repo and its contributors page, and two in `pelican/pelican.php` for the "Report A Bug" link that gets rendered into the WHMCS admin page, one of which is already commented out but I flipped it anyway so the two don't drift apart.

The only thing worth noting is that the bug report link is the one users actually see and click, so it's the one that's most visible if it ever stops going anywhere useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository links in the module description and credits.
  * Corrected the login page’s bug-report link to point to the current repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->